### PR TITLE
Fix website link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Ryan Orendorff's Website
 ========================
 
 This is my personal website, which can be reached at
-[ryan.orendorff.io](ryan.orendorff.io). I write about functional programming,
+[ryan.orendorff.io](https://ryan.orendorff.io). I write about functional programming,
 math, and sometimes medical imaging!
 
 All posts can be found in `src/posts`; each includes directions on how to run


### PR DESCRIPTION
For some reason, this linked to github without the `https://` prefix.