### PR TITLE
Update nixpkgs, hakyll, remove niv from shell

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,22 +17,22 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
-        "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
+        "rev": "351d8bc316bf901a81885bab5f52687ec8ccab6e",
+        "sha256": "1yzhz7ihkh6p2sxhp3amqfbmm2yqzaadqqii1xijymvl8alw5rrr",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/351d8bc316bf901a81885bab5f52687ec8ccab6e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "release-20.09",
+        "branch": "release-22.05",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e111e9d4c0570486f990f8000d91694075b7cea1",
-        "sha256": "0fll5nsx8bwhlv3zkg1zdr76kvcxcriq4d7wgl6lbzn91xybyl2n",
+        "rev": "695b3515251873e0a7e2021add4bba643c56cde3",
+        "sha256": "0hhn6li42s8awkpnc375zlzh3zk8lfsvg50mb03iq88lywbaikjg",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e111e9d4c0570486f990f8000d91694075b7cea1.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/695b3515251873e0a7e2021add4bba643c56cde3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -31,8 +31,28 @@ let
           if spec ? branch then "refs/heads/${spec.branch}" else
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules == true
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                {}
+            else {};
+        in
+          if nixSupportsSubmodules
+          then { inherit submodules; }
+          else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
+      builtins.fetchGit
+        ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 

--- a/shell.nix
+++ b/shell.nix
@@ -5,5 +5,5 @@ let
   site = import ./nix/site.nix;
 in pkgs.mkShell {
   inputsFrom = [ site.env ];
-  buildInputs = [ niv pkgs.nixfmt ];
+  buildInputs = [ pkgs.nixfmt ];
 }

--- a/src/ryanorendorff-website.cabal
+++ b/src/ryanorendorff-website.cabal
@@ -7,6 +7,6 @@ executable site
   main-is:          site.hs
   build-depends:    base == 4.*
                   , filepath
-                  , hakyll == 4.13.*
+                  , hakyll ==  4.15.*
   ghc-options:      -threaded
   default-language: Haskell2010


### PR DESCRIPTION
Old version would not build on x86 (I assume this is because macOS updated and the wrapper was now incorrect). Updated versions.

Niv will not build due to a Haskell dependency not building, but ideally niv will be replaced with flakes in this repository soon.