### PR TITLE
[images] Add basic png and jpg support

### DIFF
--- a/src/ryanorendorff-website.cabal
+++ b/src/ryanorendorff-website.cabal
@@ -9,6 +9,7 @@ executable site
                   , containers == 0.6.4.*
                   , filepath == 1.4.2.*
                   , hakyll == 4.15.*
+                  , hakyll-images == 1.2.*
                   , pandoc == 2.17.*
                   , pandoc-types == 1.22.*
                   , skylighting-core == 0.12.*

--- a/src/site.hs
+++ b/src/site.hs
@@ -12,6 +12,11 @@ import           Data.Yaml (decodeEither', ParseException)
 import           Data.Text.Encoding (encodeUtf8)
 
 import           Hakyll
+import           Hakyll.Images ( loadImage
+                               , compressJpgCompiler
+                               , resizeImageCompiler
+                               , scaleImageCompiler
+                               )
 
 --------------------------------------------------------------------------------
 
@@ -100,6 +105,19 @@ main = do
     match "fonts/**" $ do
         route   idRoute
         compile copyFileCompiler
+
+    -- Compress all source Jpegs to a Jpeg quality of 50 (maximum of 100)
+    match "posts/**.jpg" $ do
+        route idRoute
+        compile $ loadImage
+            >>= compressJpgCompiler 50
+
+    -- Scale images to fit within a 600x400 box
+    -- Aspect ratio will be preserved
+    match "posts/**.png" $ do
+        route idRoute
+        compile $ loadImage
+            >>= scaleImageCompiler 600 400
 
     match ("posts/*/*.lhs"
            .||. ("posts/*/*.md" .&&. complement ("posts/*/README.md"))


### PR DESCRIPTION
Images for a post will need to go into `posts/*/images/*` to work correctly. If they are placed at the root level of the post then the following error occurs:

```
[ERROR] Hakyll.Core.Compiler.Require.load: posts/whatever/whatever.png (snapshot _final) was found in the cache, but does not have the right type: expected [Char] but got Image
```