### PR TITLE
[caption] Center and automatic number figures

### DIFF
--- a/src/css/default.css
+++ b/src/css/default.css
@@ -116,6 +116,10 @@ h2 {
   text-align: left;
 }
 
+article {
+  counter-reset: figures;
+}
+
 article .title {
   font-weight: 700;
   font-style: bold;
@@ -159,6 +163,16 @@ hr {
 .quiet {
     color: #666;
     font-size: 11pt
+}
+
+figure {
+  display: inline-block;
+  text-align: center;
+  counter-increment: figures;
+}
+
+figure figcaption:before {
+	content: 'Fig. ' counter(figures) ': ';
 }
 
 @media (max-width: 319px) {


### PR DESCRIPTION
May need to change the automatic numbering later: the figure count is not accessible to pandoc at the moment since it is applied by CSS when the page loads.